### PR TITLE
feat: Migrate to Nx monorepo, refactor to TypeScript, and add audio-worklet integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soundtouchjs/monorepo",
-  "version": "0.3.9",
+  "version": "0.3.8",
   "private": true,
   "description": "SoundTouchJS monorepo",
   "license": "LGPL-2.1",

--- a/packages/audio-worklet/package.json
+++ b/packages/audio-worklet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soundtouchjs/audio-worklet",
-  "version": "0.3.9",
+  "version": "0.3.8",
   "description": "AudioWorklet implementation of the SoundTouchJS library",
   "license": "LGPL-2.1",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soundtouchjs/core",
-  "version": "0.3.9",
+  "version": "0.3.8",
   "description": "An audio processing library for manipulating Web Audio Contexts",
   "license": "LGPL-2.1",
   "type": "module",


### PR DESCRIPTION
BREAKING CHANGE:
- Convert legacy soundtouchjs repo to Nx monorepo structure
- Rename package from soundtouchjs to @soundtouchjs/core (ESM only)
- Refactor all source code to strict TypeScript, ES2024, and ESNext modules
- Remove all CommonJS and legacy build artifacts

Features and improvements:
- Add @soundtouchjs/audio-worklet package with AudioWorkletProcessor and SoundTouchNode
- Implement AudioParam-based control for pitch, tempo, rate, pitchSemitones, and playbackRate
- Demo app rewritten with dual-mode (AudioBuffer and Audio Element)
- Code snippet display and UI improvements
- Update documentation for new API, key switching, and usage patterns
- Update and expand unit tests for new features
- Update root README and package READMEs for v0.4.0 release