### PR TITLE
fix(@soundtouchjs/audio-worklet): Expand range

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ stNode.pitch.value = 0.9;
 source.start();
 ```
 
+The audio-worklet package exposes wider real-time control ranges for `pitch`, `tempo`, `rate`, and `playbackRate` than earlier releases. Those controls are intentionally capped to balance flexibility with predictable real-time behavior: more extreme values can increase artifacts, reduce output quality, and make buffer behavior less stable on small AudioWorklet render blocks.
+
 ### PitchShifter (ScriptProcessorNode)
 
 The `@soundtouchjs/core` package provides a higher-level `PitchShifter` class with built-in playback tracking. This uses `ScriptProcessorNode`, which is deprecated but widely supported.

--- a/packages/audio-worklet/README.md
+++ b/packages/audio-worklet/README.md
@@ -86,13 +86,15 @@ stNode.pitchSemitones.value = -3;
 stNode.pitch.linearRampToValueAtTime(2.0, audioCtx.currentTime + 5);
 ```
 
-| Parameter        | Default | Range      | Description                                        |
-| ---------------- | ------- | ---------- | -------------------------------------------------- |
-| `pitch`          | 1.0     | 0.25 – 4.0 | Pitch multiplier (1.0 = original)                  |
-| `tempo`          | 1.0     | 0.25 – 4.0 | Tempo multiplier (1.0 = original)                  |
-| `rate`           | 1.0     | 0.25 – 4.0 | Playback rate (affects both pitch and tempo)       |
-| `pitchSemitones` | 0       | -24 – 24   | Pitch shift in semitones (combined with `pitch`)   |
-| `playbackRate`   | 1.0     | 0.25 – 4.0 | Source playback rate (for auto pitch compensation) |
+| Parameter        | Default | Range     | Description                                        |
+| ---------------- | ------- | --------- | -------------------------------------------------- |
+| `pitch`          | 1.0     | 0.1 – 8.0 | Pitch multiplier (1.0 = original)                  |
+| `tempo`          | 1.0     | 0.1 – 8.0 | Tempo multiplier (1.0 = original)                  |
+| `rate`           | 1.0     | 0.1 – 8.0 | Playback rate (affects both pitch and tempo)       |
+| `pitchSemitones` | 0       | -24 – 24  | Pitch shift in semitones (combined with `pitch`)   |
+| `playbackRate`   | 1.0     | 0.1 – 8.0 | Source playback rate (for auto pitch compensation) |
+
+These ranges are intentionally broader than the typical musical sweet spot, but still bounded for real-time stability. Values outside this window tend to produce more audible artifacts, less predictable output, and higher risk of buffer starvation or unnatural sounding results, especially in the AudioWorklet's small render blocks. For most material, settings closer to `1.0` will sound cleaner.
 
 ### Full example — AudioBuffer
 

--- a/packages/audio-worklet/src/processor.ts
+++ b/packages/audio-worklet/src/processor.ts
@@ -35,22 +35,22 @@ class SoundTouchProcessor extends AudioWorkletProcessor {
       {
         name: 'pitch',
         defaultValue: 1.0,
-        minValue: 0.25,
-        maxValue: 4.0,
+        minValue: 0.1,
+        maxValue: 8.0,
         automationRate: 'k-rate',
       },
       {
         name: 'tempo',
         defaultValue: 1.0,
-        minValue: 0.25,
-        maxValue: 4.0,
+        minValue: 0.1,
+        maxValue: 8.0,
         automationRate: 'k-rate',
       },
       {
         name: 'rate',
         defaultValue: 1.0,
-        minValue: 0.25,
-        maxValue: 4.0,
+        minValue: 0.1,
+        maxValue: 8.0,
         automationRate: 'k-rate',
       },
       {
@@ -63,8 +63,8 @@ class SoundTouchProcessor extends AudioWorkletProcessor {
       {
         name: 'playbackRate',
         defaultValue: 1.0,
-        minValue: 0.25,
-        maxValue: 4.0,
+        minValue: 0.1,
+        maxValue: 8.0,
         automationRate: 'k-rate',
       },
     ];


### PR DESCRIPTION
Widened the value range of the `pitch`, `tempo`, `rate` and `playbackRate` worklet 
`parameterDescriptors` along with documentation of boundaries.

Closes #56