### PR TITLE
feat(demo): Add loop playback toggle and beginner Web Audio docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ This project is an [Nx](https://nx.dev) monorepo managed with [pnpm](https://pnp
 
 A development [demo app](apps/demo/) is included for testing both packages in a browser.
 
+If you are new to Web Audio, start with the demo guide: [apps/demo/README.md](apps/demo/README.md).
+
+## Documentation
+
+- Core package API and concepts: [packages/core/README.md](packages/core/README.md)
+- AudioWorklet package API and setup: [packages/audio-worklet/README.md](packages/audio-worklet/README.md)
+- Beginner Web Audio + demo architecture guide: [apps/demo/README.md](apps/demo/README.md)
+
 ## Quick start
 
 ### AudioWorklet (recommended)
@@ -99,6 +107,8 @@ pnpm dev
 ```
 
 Opens a browser at `http://localhost:8080` with sliders for tempo, pitch, key, and volume. The demo uses `@soundtouchjs/audio-worklet` under the hood.
+
+For a beginner-oriented walkthrough of the signal graph, playback modes, loop behavior, and parameter cause/effect, see [apps/demo/README.md](apps/demo/README.md).
 
 Music: "Actionable" from [Bensound.com](http://bensound.com). This is a limited use license — refer to [their licensing](https://www.bensound.com/licensing) for details.
 

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -1,0 +1,149 @@
+# Demo Guide: Web Audio + SoundTouchJS
+
+This demo is intentionally simple in UI but non-trivial in audio behavior.
+If you are new to Web Audio, read this once before editing `src/main.ts`.
+
+## Mental model
+
+Web Audio is a graph of connected nodes:
+
+`source -> processor -> gain -> destination`
+
+In this demo, that graph is:
+
+1. Source:
+- `AudioBufferSourceNode` in Buffer mode
+- `HTMLAudioElement` (wrapped by `MediaElementAudioSourceNode`) in Element mode
+
+2. Processor:
+- `SoundTouchNode` from `@soundtouchjs/audio-worklet`
+
+3. Output control:
+- `GainNode` for volume
+
+4. Speakers:
+- `audioCtx.destination`
+
+## Why there are two playback modes
+
+The demo shows two common Web Audio input strategies:
+
+1. Buffer mode:
+- You fetch/decode audio into an `AudioBuffer`
+- You create an `AudioBufferSourceNode` to play it
+- Good for precise seeking and custom transport logic
+
+2. Element mode:
+- You use a regular `<audio>` element as source
+- Good when you want native media controls or browser buffering behavior
+
+Both modes route through `SoundTouchNode` so pitch and tempo controls are consistent.
+
+## Important Web Audio behavior (newcomer checklist)
+
+1. `AudioContext` starts suspended in many browsers until user interaction.
+- That is why the demo calls `audioCtx.resume()` in play paths.
+
+2. `AudioBufferSourceNode` is one-shot.
+- After `start()`, you cannot restart the same node.
+- Pause/resume works by creating a new source node and starting from an offset.
+
+3. `createMediaElementSource()` should be done once per media element and context.
+- The demo stores `elementSourceNode` and reuses it.
+
+4. Time domains matter.
+- `audioCtx.currentTime` is wall-clock time in the audio engine.
+- `pauseOffset` is source time (position in track).
+- With tempo changes, converting between these domains is required for accurate progress/seek.
+
+5. Looping belongs to the source transport.
+- Buffer mode: `sourceNode.loop`
+- Element mode: `audioEl.loop`
+- `SoundTouchNode` does processing, not transport lifecycle.
+
+## SoundTouch parameter cause and effect
+
+The demo uses a recommended pairing:
+
+1. Set source playback speed with transport playback rate:
+- Buffer mode: `sourceNode.playbackRate.value = tempo`
+- Element mode: `audioEl.playbackRate = tempo`
+
+2. Mirror that rate to SoundTouch:
+- `stNode.playbackRate.value = tempo`
+
+This keeps SoundTouch's pitch compensation aligned with source speed.
+
+3. Apply pitch controls separately:
+- `stNode.pitch.value` for continuous ratio
+- `stNode.pitchSemitones.value` for key changes in semitones
+
+4. Set output volume after processing:
+- `gainNode.gain.value`
+
+## Why `preservesPitch = false` is set for HTML audio
+
+Browsers often apply their own pitch correction when media playback rate changes.
+If that remains enabled, both browser and SoundTouch try to affect pitch.
+
+Setting `audioEl.preservesPitch = false` ensures SoundTouch is the single pitch authority.
+
+## Buffer mode transport logic explained
+
+Buffer mode tracks three things:
+
+1. `playStartTime`:
+- `audioCtx.currentTime` at the moment playback started/resumed
+
+2. `pauseOffset`:
+- Source position in seconds where playback should start next
+
+3. `currentTempo`:
+- Needed to convert elapsed wall time into elapsed source time
+
+When pausing or changing tempo during playback, the demo does:
+
+`pauseOffset += (audioCtx.currentTime - playStartTime) * currentTempo`
+
+This is the key conversion that keeps state coherent.
+
+## Looping behavior details
+
+1. Toggle state is centralized in `setLoop(enabled)`.
+2. Existing active source gets updated immediately.
+3. New buffer sources inherit loop flag on creation.
+4. Progress display wraps with modulo when loop is on.
+
+Without wrapped progress, UI would pin at 100% while audio continues looping.
+
+## Common mistakes and symptoms
+
+1. Forgot `await SoundTouchNode.register(...)`
+- Symptom: node creation fails because processor is unknown.
+
+2. Source playback rate and `stNode.playbackRate` are out of sync
+- Symptom: pitch sounds wrong when changing tempo.
+
+3. Reusing a started `AudioBufferSourceNode`
+- Symptom: no sound after pause/resume attempt.
+
+4. Not calling `audioCtx.resume()` from a user gesture path
+- Symptom: graph appears connected but silent.
+
+5. Leaving `audioEl.preservesPitch` enabled
+- Symptom: double pitch handling artifacts.
+
+## Fast map from concepts to code
+
+1. Graph setup and processor registration: `src/main.ts` init block
+2. Buffer transport lifecycle: `bufferPlay()` and `bufferPause()`
+3. Element transport lifecycle: `elementPlay()` and `connectAudioElement()`
+4. Loop behavior: `setLoop()` and `updateProgress()`
+5. Tempo and pitch controls: slider event handlers at the bottom
+
+## Development tips
+
+1. Change one transport variable at a time (loop, then tempo, then seek).
+2. Verify both modes after every change.
+3. Keep comments focused on cause/effect, not UI wording.
+4. If behavior differs between modes, check source-specific APIs first.

--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -83,6 +83,10 @@
     <div id="elementControls" style="display: none">
       <audio id="audioEl" src="./bensound-actionable.mp3" controls></audio>
     </div>
+    <label style="display: flex; gap: 1rem">
+      <input type="checkbox" id="loopToggle" />
+      Loop playback
+    </label>
     Rate:
     <input
       type="range"

--- a/apps/demo/src/main.ts
+++ b/apps/demo/src/main.ts
@@ -2,6 +2,18 @@ import { SoundTouchNode } from '@soundtouchjs/audio-worklet';
 
 type SourceMode = 'buffer' | 'element';
 
+/**
+ * Demo architecture in one sentence:
+ * source node (AudioBufferSourceNode or HTMLMediaElement) -> SoundTouchNode -> GainNode -> destination.
+ *
+ * Cause/effect summary:
+ * - Source playbackRate controls transport speed (tempo).
+ * - SoundTouchNode.playbackRate mirrors source playbackRate so pitch compensation is correct.
+ * - SoundTouchNode.pitch and pitchSemitones apply musical pitch changes on top.
+ *
+ * For a full beginner-focused Web Audio walkthrough, see ../README.md in this app.
+ */
+
 function formatTime(secs: number): string {
   const mins = Math.floor(secs / 60);
   const seconds = Math.floor(secs - mins * 60);
@@ -42,10 +54,13 @@ const duration = document.getElementById('duration') as HTMLSpanElement;
 const progressMeter = document.getElementById(
   'progressMeter',
 ) as HTMLProgressElement;
+const loopToggle = document.getElementById('loopToggle') as HTMLInputElement;
 const audioEl = document.getElementById('audioEl') as HTMLAudioElement;
 const codeBlock = document.getElementById('codeBlock') as HTMLDivElement;
 
 // --- State ---
+// `pauseOffset` is tracked in source-time seconds (not wall clock time).
+// This lets seek/pause/resume stay correct when tempo changes.
 let audioCtx: AudioContext;
 let gainNode: GainNode;
 let stNode: SoundTouchNode;
@@ -58,6 +73,7 @@ let pauseOffset = 0;
 let rafId = 0;
 let currentTempo = 1;
 let currentPitch = 1;
+let loopEnabled = false;
 let activeMode: SourceMode = 'buffer';
 
 // --- Code snippets ---
@@ -77,6 +93,7 @@ const audioBuffer = await audioCtx.decodeAudioData(buffer);
 
 const source = audioCtx.createBufferSource();
 source.buffer = audioBuffer;
+source.loop = true;
 source.playbackRate.value = tempo;    // tempo via playback rate
 source.connect(stNode);
 
@@ -101,6 +118,7 @@ stNode.connect(gainNode);
 const source = audioCtx.createMediaElementSource(audioEl);
 source.connect(stNode);
 
+audioEl.loop = true;
 audioEl.preservesPitch = false;       // let SoundTouch handle pitch
 audioEl.playbackRate = tempo;         // tempo via element playback rate
 stNode.playbackRate.value = tempo;    // tell processor the source rate
@@ -137,33 +155,77 @@ function connectAudioElement(): void {
   elementSourceNode.connect(stNode);
 }
 
+/**
+ * Converts an arbitrary source-time position into a valid playback offset.
+ *
+ * Cause/effect:
+ * - Loop off  -> clamp to end of file.
+ * - Loop on   -> wrap around with modulo so repeated playback stays continuous.
+ */
+function normalizeOffset(position: number): number {
+  if (!audioBuffer) return position;
+  if (audioBuffer.duration <= 0) return 0;
+  if (loopEnabled) {
+    return position % audioBuffer.duration;
+  }
+  return Math.min(position, audioBuffer.duration);
+}
+
+/**
+ * Single source of truth for loop state.
+ * Applies the toggle to both playback modes so behavior is predictable when switching modes.
+ */
+function setLoop(enabled: boolean): void {
+  loopEnabled = enabled;
+  loopToggle.checked = enabled;
+  if (sourceNode) {
+    sourceNode.loop = enabled;
+  }
+  audioEl.loop = enabled;
+}
+
 // --- Buffer mode: play/pause/progress ---
+/**
+ * UI progress is derived from source-time, not output-time.
+ * This keeps the meter aligned with seek and tempo changes.
+ */
 function updateProgress(): void {
   if (!audioBuffer || !isPlaying) return;
   const wallElapsed = audioCtx.currentTime - playStartTime;
   const sourceElapsed = pauseOffset + wallElapsed * currentTempo;
-  const perc = Math.min(sourceElapsed / audioBuffer.duration, 1);
-  currTime.innerHTML = formatTime(sourceElapsed);
+  const displayElapsed = loopEnabled
+    ? sourceElapsed % audioBuffer.duration
+    : sourceElapsed;
+  const perc = loopEnabled
+    ? displayElapsed / audioBuffer.duration
+    : Math.min(displayElapsed / audioBuffer.duration, 1);
+  currTime.innerHTML = formatTime(displayElapsed);
   progressMeter.value = perc * 100;
-  if (perc >= 1) {
+  if (!loopEnabled && perc >= 1) {
     bufferPause();
     return;
   }
   rafId = requestAnimationFrame(updateProgress);
 }
 
+/**
+ * AudioBufferSourceNode is one-shot, so every play/resume creates a new source node.
+ * The offset determines where playback begins in the source buffer.
+ */
 function bufferPlay(): void {
   if (!audioBuffer) return;
   sourceNode = audioCtx.createBufferSource();
   sourceNode.buffer = audioBuffer;
+  sourceNode.loop = loopEnabled;
   sourceNode.playbackRate.value = currentTempo;
   sourceNode.connect(stNode);
   stNode.playbackRate.value = currentTempo;
 
+  pauseOffset = normalizeOffset(pauseOffset);
   playStartTime = audioCtx.currentTime;
   sourceNode.start(0, pauseOffset);
   sourceNode.onended = () => {
-    if (isPlaying) bufferPause();
+    if (isPlaying && !loopEnabled) bufferPause();
   };
 
   audioCtx.resume().then(() => {
@@ -173,6 +235,10 @@ function bufferPlay(): void {
   });
 }
 
+/**
+ * Stops the current source node and converts wall-clock elapsed time back into source-time offset.
+ * This is what makes pause/resume and tempo edits deterministic.
+ */
 function bufferPause(resume = false): void {
   if (sourceNode) {
     sourceNode.onended = null;
@@ -182,6 +248,7 @@ function bufferPause(resume = false): void {
   }
   if (isPlaying) {
     pauseOffset += (audioCtx.currentTime - playStartTime) * currentTempo;
+    pauseOffset = normalizeOffset(pauseOffset);
   }
   cancelAnimationFrame(rafId);
   isPlaying = resume;
@@ -189,9 +256,14 @@ function bufferPause(resume = false): void {
 }
 
 // --- Element mode ---
+/**
+ * For media elements, playbackRate changes transport speed and would normally pitch-shift.
+ * Setting preservesPitch=false delegates pitch handling to SoundTouch for consistent behavior.
+ */
 function elementPlay(): void {
   audioCtx.resume();
   connectAudioElement();
+  audioEl.loop = loopEnabled;
   audioEl.preservesPitch = false;
   audioEl.playbackRate = currentTempo;
   stNode.playbackRate.value = currentTempo;
@@ -199,6 +271,10 @@ function elementPlay(): void {
 }
 
 // --- Mode switching ---
+/**
+ * Switching mode resets transport-related UI state while keeping processing graph intact.
+ * This avoids stale offsets from one source type leaking into the other.
+ */
 function setMode(mode: SourceMode): void {
   if (isPlaying) {
     if (activeMode === 'buffer') bufferPause();
@@ -238,12 +314,17 @@ setMode('buffer');
 
 playBtn.onclick = bufferPlay;
 stopBtn.onclick = () => bufferPause();
+loopToggle.onchange = () => setLoop(loopToggle.checked);
+setLoop(false);
 
 tempoSlider.addEventListener('input', () => {
   const newTempo = Number(tempoSlider.value);
   if (activeMode === 'buffer') {
+    // Fold elapsed wall time into source offset before changing tempo,
+    // then restart accumulation from the new tempo.
     if (isPlaying) {
       pauseOffset += (audioCtx.currentTime - playStartTime) * currentTempo;
+      pauseOffset = normalizeOffset(pauseOffset);
       playStartTime = audioCtx.currentTime;
     }
     if (sourceNode) sourceNode.playbackRate.value = newTempo;


### PR DESCRIPTION
- add loop toggle UI and shared loop state for buffer and element playback modes

- update progress, pause/resume, seek, and tempo-change offset logic for looped playback

- document demo architecture and Web Audio cause-and-effect in app docs

- link demo guide from the root README documentation sections

Closes #31